### PR TITLE
implemented signup and leave methods. uid in headers

### DIFF
--- a/levelupapi/models/event.py
+++ b/levelupapi/models/event.py
@@ -10,3 +10,11 @@ class Event(models.Model):
     date = models.DateField()
     time = models.TimeField()
     organizer = models.ForeignKey('Gamer', on_delete=models.CASCADE)
+
+    @property
+    def joined(self):
+        return self.__joined
+
+    @joined.setter
+    def joined(self, value):
+        self.__joined = value

--- a/levelupapi/views/game.py
+++ b/levelupapi/views/game.py
@@ -69,7 +69,6 @@ class GameView(ViewSet):
         game.delete()
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
-
     def update(self, request, pk):
         """Handle PUT requests for a game
 


### PR DESCRIPTION
This pull request introduces functionality to manage event participation by adding methods for users to sign up for or leave events, along with a new property to track whether a user has joined a specific event. It also includes minor cleanup in unrelated code.

### Event Participation Enhancements:

1. **Added `joined` property to `Event` model**:
   - Introduced a `joined` property with getter and setter methods to track whether a user has joined an event. (`levelupapi/models/event.py`, [levelupapi/models/event.pyR13-R20](diffhunk://#diff-2f2b7bd098767aabee6745a8f60bbe8337cbd0acddc03358fca3539e77429fe6R13-R20))

2. **Updated `list` method in `EventView`**:
   - Modified the `list` method to set the `joined` property for each event based on whether the current user is signed up. This uses the `EventGamer` join table for validation. (`levelupapi/views/event.py`, [levelupapi/views/event.pyR39-R51](diffhunk://#diff-fb00215a54e07d4ca29bee6f5debebeadd27c99f403588378166d99a604c1ec2R39-R51))

3. **Added `signup` and `leave` methods in `EventView`**:
   - Introduced two new routes:
     - `signup`: Allows a user to sign up for an event via a POST request.
     - `leave`: Allows a user to leave an event via a DELETE request.
   - Both methods use the `EventGamer` join table to manage participation. (`levelupapi/views/event.py`, [levelupapi/views/event.pyR107-R156](diffhunk://#diff-fb00215a54e07d4ca29bee6f5debebeadd27c99f403588378166d99a604c1ec2R107-R156))

4. **Updated `EventSerializer`**:
   - Modified the serializer to include the new `joined` field, enabling its inclusion in API responses. (`levelupapi/views/event.py`, [levelupapi/views/event.pyR107-R156](diffhunk://#diff-fb00215a54e07d4ca29bee6f5debebeadd27c99f403588378166d99a604c1ec2R107-R156))

### Minor Cleanup:

5. **Removed unnecessary blank line in `GameView`**:
   - Deleted an extra blank line in the `destroy` method for improved readability. (`levelupapi/views/game.py`, [levelupapi/views/game.pyL72](diffhunk://#diff-7113b9f89f29177e6e510cacf9587c7172ba7a7f1705e00b0e5ef56bc49eb3eaL72))